### PR TITLE
(fix) key spreading

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-snap-carousel",
-    "version": "3.9.2-alpha",
+    "version": "3.9.3",
     "description": "Swiper/carousel component for React Native with previews, multiple layouts, parallax images, performant handling of huge numbers of items, and RTL support. Compatible with Android & iOS.",
     "main": "src/index.js",
     "repository": {

--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -1358,7 +1358,7 @@ export default class Carousel extends Component {
         const ScrollViewComponent = typeof useScrollView === 'function' ? useScrollView : AnimatedScrollView
 
         return this._needsScrollView() ? (
-            <ScrollViewComponent {...props}>
+            <ScrollViewComponent key={key} {...props}>
                 {
                     this._getCustomData().map((item, index) => {
                         return this._renderItem({ item, index });
@@ -1366,7 +1366,7 @@ export default class Carousel extends Component {
                 }
             </ScrollViewComponent>
         ) : (
-            <AnimatedFlatList {...props} />
+            <AnimatedFlatList key={key} {...props} />
         );
     }
 }

--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -1343,7 +1343,7 @@ export default class Carousel extends Component {
     }
 
     render () {
-        const { data, renderItem, useScrollView } = this.props;
+        const { data, renderItem, useScrollView, key, ...otherProps } = this.props;
 
         if (!data || !renderItem) {
             return null;
@@ -1351,7 +1351,7 @@ export default class Carousel extends Component {
 
         const props = {
             ...this._getComponentOverridableProps(),
-            ...this.props,
+            ...otherProps,
             ...this._getComponentStaticProps()
         };
 

--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -1230,12 +1230,13 @@ export default class Carousel extends Component {
         } : undefined;
 
         const mainDimension = vertical ? { height: itemHeight } : { width: itemWidth };
-        const specificProps = this._needsScrollView() ? {
-            key: keyExtractor ? keyExtractor(item, index) : this._getKeyExtractor(item, index)
-        } : {};
+        const key = (() => {
+            if (!this._needsScrollView()) return undefined;
+            return keyExtractor?.(item, index) ?? this._getKeyExtractor(item, index);
+          })();
 
         return (
-            <Component style={[mainDimension, slideStyle, animatedStyle]} pointerEvents={'box-none'} {...specificProps}>
+            <Component style={[mainDimension, slideStyle, animatedStyle]} pointerEvents={'box-none'} key={key}>
                 { renderItem({ item, index }, parallaxProps) }
             </Component>
         );

--- a/src/parallaximage/ParallaxImage.js
+++ b/src/parallaximage/ParallaxImage.js
@@ -184,6 +184,7 @@ export default class ParallaxImage extends Component {
         return (
             <AnimatedImageComponent
               {...other}
+              key={key}
               style={[styles.image, style, requiredStyles, dynamicStyles]}
               onLoad={this._onLoad}
               onError={status !== 3 ? this._onError : undefined} // prevent infinite-loop bug

--- a/src/parallaximage/ParallaxImage.js
+++ b/src/parallaximage/ParallaxImage.js
@@ -153,6 +153,7 @@ export default class ParallaxImage extends Component {
             parallaxFactor,
             style,
             AnimatedImageComponent,
+            key,
             ...other
         } = this.props;
 


### PR DESCRIPTION
### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Tested features checklist
<!--
IMPORTANT: Please make sure that none of these features have been broken by your changes.
It's easy to overlook something you didn't use yet.
-->
- [ ] Default setup ([example](https://github.com/meliorence/react-native-snap-carousel/blob/master/example/src/index.js#L46-L87))
- [ ] Carousels with and without momentum enabled ([prop `enableMomentum`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Vertical carousels ([prop `vertical`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Slide alignment ([prop `activeSlideAlignment`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#style-and-animation))
- [ ] Autoplay ([prop `autoplay`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#autoplay))
- [ ] Loop mode ([prop `loop`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#loop))
- [ ] `ScrollView`/`FlatList` carousels ([prop `useScrollView`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] [Callback methods](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#callbacks)
- [ ] [`ParallaxImage` component](https://github.com/meliorence/react-native-snap-carousel#parallaximage-component)
- [ ] [`Pagination` component](https://github.com/meliorence/react-native-snap-carousel#pagination-component)
- [ ] [Layouts and custom interpolations](https://github.com/meliorence/react-native-snap-carousel#layouts-and-custom-interpolations)
